### PR TITLE
Refine AudioPlayer and AudioService to stop auto playing after pause pressed

### DIFF
--- a/app/src/main/java/wishcantw/vocabulazy/service/AudioPlayer.java
+++ b/app/src/main/java/wishcantw/vocabulazy/service/AudioPlayer.java
@@ -44,7 +44,8 @@ public class AudioPlayer implements AudioPlayerListener {
     public static final String IDLE = "idle";
     public static final String PLAYING = "playing";
     public static final String PAUSE = "pause";
-    public static final String HALT_BY_SCROLLING = "halt-by-scrolling";
+    public static final String HALT_FROM_PLAYING_BY_SCROLLING = "halt-from-playing-by-scrolling";
+    public static final String HALT_FROM_PAUSE_BY_SCROLLING = "halt-from-pause-by-scrolling";
     public static final String HALT_BY_FOCUS_LOSS = "halt-by-focus-loss";
 
     private Context mContext;
@@ -114,6 +115,10 @@ public class AudioPlayer implements AudioPlayerListener {
         AudioManager audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
         int result = audioManager.requestAudioFocus(this, AudioManager.STREAM_MUSIC, AudioManager.AUDIOFOCUS_GAIN);
         isAudioFocused = (result == AudioManager.AUDIOFOCUS_REQUEST_GRANTED);
+    }
+
+    public String getPlayerState() {
+        return mPlayerState;
     }
 
     public void releaseAudioFocus(Context context) {
@@ -239,10 +244,15 @@ public class AudioPlayer implements AudioPlayerListener {
     }
 
     public void haltPlayer() {
+        String playerState = mPlayerState;
         if (vlTextToSpeech != null) {
             vlTextToSpeech.stop();
         }
-        updatePlayerInfo(mItemIndex, mSentenceIndex, mPlayingField, HALT_BY_SCROLLING);
+        if (playerState.equals(PLAYING)) {
+            updatePlayerInfo(mItemIndex, mSentenceIndex, mPlayingField, HALT_FROM_PLAYING_BY_SCROLLING);
+        } else {
+            updatePlayerInfo(mItemIndex, mSentenceIndex, mPlayingField, HALT_FROM_PAUSE_BY_SCROLLING);
+        }
     }
 
     public void startTimer() {
@@ -305,7 +315,7 @@ public class AudioPlayer implements AudioPlayerListener {
         String playingField = mPlayingField;
         String playerState = mPlayerState;
 
-        if (playerState.equals(HALT_BY_SCROLLING) || playerState.equals(PAUSE)) return;
+        if (playerState.equals(HALT_FROM_PLAYING_BY_SCROLLING) || playerState.equals(HALT_FROM_PAUSE_BY_SCROLLING) || playerState.equals(PAUSE)) return;
 
         if (mOptionSettings == null || mBroadcastTrigger == null) {
             return;

--- a/app/src/main/java/wishcantw/vocabulazy/service/AudioService.java
+++ b/app/src/main/java/wishcantw/vocabulazy/service/AudioService.java
@@ -143,6 +143,10 @@ public class AudioService extends IntentService {
                 mAudioPlayer.resetItemLoop();
                 mAudioPlayer.resetListLoop();
                 mAudioPlayer.resetTimer();
+                // DO NOT change the playing state to PLAYING if current state is PAUSE
+                if (mAudioPlayer.getPlayerState().equals(AudioPlayer.HALT_FROM_PAUSE_BY_SCROLLING)) {
+                    break;
+                }
             case START_PLAYING:
                 if (intent == null)
                     break;


### PR DESCRIPTION
Add two audio player states to handle the case that after pause the scrolling should not trigger playing again until playing button is pressed.