### PR TITLE
Bug fixed - #97

### DIFF
--- a/app/src/main/java/wishcantw/vocabulazy/activities/player/activity/PlayerActivity.java
+++ b/app/src/main/java/wishcantw/vocabulazy/activities/player/activity/PlayerActivity.java
@@ -35,6 +35,9 @@ public class PlayerActivity extends ParentActivity implements PlayerFragment.OnP
     // tag for lesson change
     private boolean isLessonChanged = true;
 
+    // voc id to be add
+    private int vocIdToBeAdded;
+
     // player model
     private PlayerModel mPlayerModel;
 
@@ -126,6 +129,15 @@ public class PlayerActivity extends ParentActivity implements PlayerFragment.OnP
         return isLessonChanged;
     }
 
+    /**
+     * Get the vocabulary id which is being added to note
+     *
+     * @return the id of the vocabulary
+     */
+    public int getVocIdToBeAdded() {
+        return vocIdToBeAdded;
+    }
+
     /**-- PlayerFragment callback --**/
     @Override
     public void onLessonChange(int lesson) {
@@ -137,8 +149,9 @@ public class PlayerActivity extends ParentActivity implements PlayerFragment.OnP
     @Override
     public void onFavoriteClick(int vocId) {
         Logger.d(TAG, "onNewNote");
+        vocIdToBeAdded = vocId;
         PlayerAddVocToNoteDialogFragment dialogFragment = new PlayerAddVocToNoteDialogFragment();
-        dialogFragment.setSelectedVocId(vocId);
+//        dialogFragment.setSelectedVocId(vocId);
         FragmentTransaction fragmentTransaction = getSupportFragmentManager().beginTransaction();
         fragmentTransaction.add(PlayerActivity.VIEW_MAIN_RES_ID, dialogFragment, "PlayerAddVocToNoteDialogFragment");
         fragmentTransaction.addToBackStack("PlayerAddVocToNoteDialogFragment");

--- a/app/src/main/java/wishcantw/vocabulazy/activities/player/activity/PlayerActivity.java
+++ b/app/src/main/java/wishcantw/vocabulazy/activities/player/activity/PlayerActivity.java
@@ -35,6 +35,7 @@ public class PlayerActivity extends ParentActivity implements PlayerFragment.OnP
     // tag for lesson change
     private boolean isLessonChanged = true;
 
+    // TODO: 2016/11/30 The variable is used as quick solution, need re-evaluation on the structure of fragments.
     // voc id to be add
     private int vocIdToBeAdded;
 

--- a/app/src/main/java/wishcantw/vocabulazy/activities/player/fragment/PlayerAddVocToNoteDialogFragment.java
+++ b/app/src/main/java/wishcantw/vocabulazy/activities/player/fragment/PlayerAddVocToNoteDialogFragment.java
@@ -89,14 +89,15 @@ public class PlayerAddVocToNoteDialogFragment extends DialogFragmentNew<Integer>
 
     @Override
     public void onYesClick() {
-        getActivity().onBackPressed();
         int selectedNoteIndex = mPlayerAddVocToNoteDialogView.getCurrentCheckedNoteIndex();
         if (selectedNoteIndex == mNoteNameList.size()) {
+            getActivity().onBackPressed();
             if (mOnAddVocToNoteDialogFinishListener != null) {
                 mOnAddVocToNoteDialogFinishListener.onNeedNewNote();
             }
         } else {
-            mPlayerModel.addVocToNote(mSelectedVocId, selectedNoteIndex);
+            mPlayerModel.addVocToNote(((PlayerActivity) getActivity()).getVocIdToBeAdded(), selectedNoteIndex);
+            getActivity().onBackPressed();
         }
     }
 

--- a/app/src/main/java/wishcantw/vocabulazy/activities/player/fragment/PlayerNewNoteDialogFragment.java
+++ b/app/src/main/java/wishcantw/vocabulazy/activities/player/fragment/PlayerNewNoteDialogFragment.java
@@ -1,5 +1,6 @@
 package wishcantw.vocabulazy.activities.player.fragment;
 
+import android.app.Activity;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -59,14 +60,14 @@ public class PlayerNewNoteDialogFragment extends DialogFragmentNew implements Di
 
     @Override
     public void onYesClick() {
-        getActivity().onBackPressed();
-
         // get name of new note
         String newNoteString = mPlayerNewNoteDialogView.getNewNoteString();
 
         // access search model and add new note to database
         PlayerModel playerModel = ((PlayerActivity) getActivity()).getPlayerModel();
         playerModel.addNewNote(newNoteString);
+
+        getActivity().onBackPressed();
 
         if (mOnDialogFinishListener != null) {
             mOnDialogFinishListener.onNewNoteDone(newNoteString);

--- a/app/src/main/java/wishcantw/vocabulazy/activities/search/activity/SearchActivity.java
+++ b/app/src/main/java/wishcantw/vocabulazy/activities/search/activity/SearchActivity.java
@@ -33,6 +33,7 @@ public class SearchActivity extends ParentActivity implements SearchView.OnQuery
     private SearchFragment mSearchFragment;
     private SearchModel mSearchModel;
 
+    // TODO: 2016/11/30 The variable is used as quick solution, need re-evaluation on the structure of fragments.
     // vocabulary id to be added
     private int vocIdToBeAdded;
 

--- a/app/src/main/java/wishcantw/vocabulazy/activities/search/activity/SearchActivity.java
+++ b/app/src/main/java/wishcantw/vocabulazy/activities/search/activity/SearchActivity.java
@@ -33,6 +33,9 @@ public class SearchActivity extends ParentActivity implements SearchView.OnQuery
     private SearchFragment mSearchFragment;
     private SearchModel mSearchModel;
 
+    // vocabulary id to be added
+    private int vocIdToBeAdded;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -110,6 +113,15 @@ public class SearchActivity extends ParentActivity implements SearchView.OnQuery
         return mSearchModel;
     }
 
+    /**
+     * Get the id of vocabulary which is being added to a note
+     *
+     * @return the id of the vocabulary
+     */
+    public int getVocIdToBeAdded() {
+        return vocIdToBeAdded;
+    }
+
     @Override
     public boolean onQueryTextSubmit(String query) {
         return false;
@@ -125,8 +137,9 @@ public class SearchActivity extends ParentActivity implements SearchView.OnQuery
     @Override
     public void onSearchListClick(int vocId) {
         Logger.d(TAG, "onSearchListClick");
+        vocIdToBeAdded = vocId;
         SearchAddVocToNoteDialogFragment dialogFragment = new SearchAddVocToNoteDialogFragment();
-        dialogFragment.setSelectedVocId(vocId);
+//        dialogFragment.setSelectedVocId(vocId);
         FragmentTransaction fragmentTransaction = getSupportFragmentManager().beginTransaction();
         fragmentTransaction.add(SearchActivity.VIEW_MAIN_RES_ID, dialogFragment, "SearchAddVocToNoteDialogFragment");
         fragmentTransaction.addToBackStack("SearchAddVocToNoteDialogFragment");

--- a/app/src/main/java/wishcantw/vocabulazy/activities/search/fragment/SearchAddVocToNoteDialogFragment.java
+++ b/app/src/main/java/wishcantw/vocabulazy/activities/search/fragment/SearchAddVocToNoteDialogFragment.java
@@ -96,8 +96,7 @@ public class SearchAddVocToNoteDialogFragment extends DialogFragmentNew<Integer>
     @Override
     public void onYesClick() {
 
-        // remove current fragment
-        getActivity().onBackPressed();
+
 
         // get selected note index
         int selectedNoteIndex = mSearchAddVocToNoteDialogView.getCurrentCheckedNoteIndex();
@@ -105,11 +104,16 @@ public class SearchAddVocToNoteDialogFragment extends DialogFragmentNew<Integer>
         // if the selected index is the last one, then pop NewNoteDialog to create new note
         // otherwise add the vocabulary to the seleceted note
         if (mSearchAddVocToNoteDialogView.getCurrentCheckedNoteIndex() == mNoteNameList.size()) {
+            // remove current fragment
+            getActivity().onBackPressed();
             if (mOnAddVocToNoteDialogFinishListener != null) {
                 mOnAddVocToNoteDialogFinishListener.onNeedNewNote();
             }
         } else {
-            mSearchModel.addVocToNote(selectedVocId, selectedNoteIndex);
+
+            mSearchModel.addVocToNote(((SearchActivity) getActivity()).getVocIdToBeAdded(), selectedNoteIndex);
+            // remove current fragment
+            getActivity().onBackPressed();
         }
     }
 

--- a/app/src/main/java/wishcantw/vocabulazy/activities/search/fragment/SearchNewNoteDialogFragment.java
+++ b/app/src/main/java/wishcantw/vocabulazy/activities/search/fragment/SearchNewNoteDialogFragment.java
@@ -71,15 +71,14 @@ public class SearchNewNoteDialogFragment extends DialogFragmentNew implements Di
 
     @Override
     public void onYesClick() {
-
-        // remove current fragment
-        getActivity().onBackPressed();
-
         // get name of new note
         String newNoteString = mSearchNewNoteDialogView.getNewNoteString();
 
         // access search model and add new note to database
         mSearchModel.addNewNote(newNoteString);
+
+        // remove current fragment
+        getActivity().onBackPressed();
 
         // notify new note has been added
         if (mOnDialogFinishListener != null) {


### PR DESCRIPTION
Fixed issue #97.
1. onBackPressed is called too early, which detaches the fragment and therefore getActivity returns null object. Now we re-arrange the time of evoking onBackPress to avoid null activity.
2. The vocabulary id which is passed to AddVocToNoteFragment does not sustain after creating new notes. The issue has been solved by using a quick, but very bad, solution which is buffering the id in activity and the fragments will be able to access the correct value while needed.