### PR TITLE
Debug the layout error if pressing the textbook item to expand the list

### DIFF
--- a/app/src/main/res/layout/item_textbook_group.xml
+++ b/app/src/main/res/layout/item_textbook_group.xml
@@ -6,8 +6,8 @@
     <LinearLayout
         android:id="@+id/view_parent"
         android:orientation="vertical"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
         android:layout_marginTop="5dp">
 
         <TextView
@@ -49,7 +49,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginRight="20dp"
-        android:layout_alignRight="@id/view_parent"
+        android:layout_alignParentRight="true"
         android:translationZ="5dp"/>
 
 </RelativeLayout>


### PR DESCRIPTION
@allencheng07 
Pull request #120 will make expandable list view layout error when textbook_item_group is pressed.
The pull request fix the bug, please help me to verify the xml file and merge.